### PR TITLE
NVMeoF and iSCSI fixes for IPv6

### DIFF
--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -311,7 +311,7 @@ ibft_to_cmdline() {
                 [ -e "${iface}"/hostname ] && read -r hostname < "${iface}"/hostname
                 if [ "$family" = "ipv6" ]; then
                     if [ -n "$ip" ]; then
-                        [ -n "$prefix" ] || prefix=64
+                        [ -n "$prefix" ] || prefix=128
                         ip="[${ip}]"
                         mask=$prefix
                     fi

--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -312,8 +312,8 @@ ibft_to_cmdline() {
                 if [ "$family" = "ipv6" ]; then
                     if [ -n "$ip" ]; then
                         [ -n "$prefix" ] || prefix=64
-                        ip="[${ip}/${prefix}]"
-                        mask=
+                        ip="[${ip}]"
+                        mask=$prefix
                     fi
                     if [ -n "$gw" ]; then
                         gw="[${gw}]"

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -172,10 +172,9 @@ nbft_parse_hfi() {
         if [ $? -ne 0 ] && [ "$adrfam" = ipv6 ]; then
             prefix=64
         fi
-        # IPv6 has different syntax for prefix/mask
+        # Use brackets for IPv6
         if [ "$adrfam" = ipv6 ]; then
-            ipaddr="[$ip/$prefix]"
-            prefix=
+            ipaddr="[$ipaddr]"
         fi
 
         gateway=$(nbft_check_empty_address \

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -170,7 +170,7 @@ nbft_parse_hfi() {
         # Need to check $? here as he above is an assignment
         # shellcheck disable=2181
         if [ $? -ne 0 ] && [ "$adrfam" = ipv6 ]; then
-            prefix=64
+            prefix=128
         fi
         # Use brackets for IPv6
         if [ "$adrfam" = ipv6 ]; then


### PR DESCRIPTION
Fixes for https://github.com/dracutdevs/dracut/pull/2184

## Changes

I've only recently been able to make real tests with IPv6 and NVMeoF boot.
This revealed the issues fixed in this PR.

The nvmf fixups should be squashed into timberlandmaster_final, the iSCSI patches should remain separate.


## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
