### PR TITLE
Minor fixes for Timberland dracut

### DIFF
--- a/modules.d/95nvmf/nvmf-autoconnect.sh
+++ b/modules.d/95nvmf/nvmf-autoconnect.sh
@@ -20,7 +20,8 @@ if [ -e /tmp/valid_nbft_entry_found ]; then
     /usr/sbin/nvme connect-nbft
     [ "$1" = timeout ] || exit 0
 fi
-if [ -f /etc/nvme/discovery.conf ] && [ $NVMF_HOSTNQN_OK ]; then
+if [ -f /etc/nvme/discovery.conf ] || [ -f /etc/nvme/config.json ] \
+    && [ "$NVMF_HOSTNQN_OK" ]; then
     # prio 3: discovery.conf from initrd
     /usr/sbin/nvme connect-all
     [ "$1" = timeout ] || exit 0

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -183,7 +183,7 @@ nbft_parse_hfi() {
             "$(nbft_run_jq -r .primary_dns_ipaddr "$hfi_json")")
         dns2=$(nbft_check_empty_address \
             "$(nbft_run_jq -r .secondary_dns_ipaddr "$hfi_json")")
-        hostname=$(nbft_run_jq -r .host_name "$hfi_json") || hostname=
+        hostname=$(nbft_run_jq -r .host_name "$hfi_json" 2> /dev/null) || hostname=
 
         echo "ip=$ipaddr::$gateway:$prefix:$hostname:$iface${vlan:+.$vlan}:none${dns1:+:$dns1}${dns2:+:$dns2}"
     fi

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -273,7 +273,7 @@ parse_nvmf_discover() {
         : > /tmp/nvmf_needs_network
     elif [ "$trtype" = "fc" ]; then
         if [ "$traddr" = "auto" ]; then
-            rm /etc/nvme/discovery.conf
+            rm -f /etc/nvme/discovery.conf /etc/nvme/config.json
             return 1
         fi
         if [ "$hosttraddr" = "none" ]; then


### PR DESCRIPTION
Two minor fixes for the dracut code

## Note about branches ##

This PR goes into the `timberland_master` branch, which I have used for the upstream PR https://github.com/dracutdevs/dracut/pull/2184, too. That branch is going to be rebased onto upstream dracut until the upstream PR is merged.

## Changes

* suppress pointless hostname warning
* support `config.json`

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #4.