### PR TITLE
fix(nvmf): test if "nvme connect-all --nbft" is supported

### DIFF
--- a/modules.d/95nvmf/nvmf-autoconnect.sh
+++ b/modules.d/95nvmf/nvmf-autoconnect.sh
@@ -6,25 +6,45 @@
 
 [ "$RD_DEBUG" != yes ] || set -x
 
+if [ "$1" = timeout ]; then
+    [ ! -f /sys/class/fc/fc_udev_device/nvme_discovery ] \
+        || echo add > /sys/class/fc/fc_udev_device/nvme_discovery
+    /usr/sbin/nvme connect-all
+    exit 0
+fi
+
 NVMF_HOSTNQN_OK=
 [ ! -f "/etc/nvme/hostnqn" ] || [ ! -f "/etc/nvme/hostid" ] || NVMF_HOSTNQN_OK=1
+
+# Only nvme-cli 2.5 or newer supports the options --nbft and --no-nbft
+# for the connect-all command.
+# Make sure we don't use unsupported options with earlier versions.
+NBFT_SUPPORTED=
+# shellcheck disable=SC2016
+/usr/sbin/nvme connect-all --help 2>&1 | sed -n '/[[:space:]]--nbft[[:space:]]/q1;$q0' \
+    || NBFT_SUPPORTED=1
 
 if [ -e /tmp/nvmf-fc-auto ] && [ "$NVMF_HOSTNQN_OK" ] \
     && [ -f /sys/class/fc/fc_udev_device/nvme_discovery ]; then
     # prio 1: cmdline override "rd.nvmf.discovery=fc,auto"
     echo add > /sys/class/fc/fc_udev_device/nvme_discovery
-    [ "$1" = timeout ] || exit 0
+    exit 0
 fi
-if [ -e /tmp/valid_nbft_entry_found ]; then
+if [ "$NBFT_SUPPORTED" ] && [ -e /tmp/valid_nbft_entry_found ]; then
     # prio 2: NBFT
     /usr/sbin/nvme connect-all --nbft
-    [ "$1" = timeout ] || exit 0
+    exit 0
 fi
 if [ -f /etc/nvme/discovery.conf ] || [ -f /etc/nvme/config.json ] \
     && [ "$NVMF_HOSTNQN_OK" ]; then
-    # prio 3: discovery.conf from initrd
-    /usr/sbin/nvme connect-all --no-nbft
-    [ "$1" = timeout ] || exit 0
+    # prio 3: configuration from initrd and/or kernel command line
+    # We can get here even if "rd.nvmf.nonbft" was given, thus use --no-nbft
+    if [ "$NBFT_SUPPORTED" ]; then
+        /usr/sbin/nvme connect-all --no-nbft
+    else
+        /usr/sbin/nvme connect-all
+    fi
+    exit 0
 fi
 if [ "$NVMF_HOSTNQN_OK" ] \
     && [ -f /sys/class/fc/fc_udev_device/nvme_discovery ]; then


### PR DESCRIPTION
... and simplify the "timeout" logic.

We can't blindly assume that "nvme connect-all --nbft" is supported; while the support for this option has been merged upstream, it hasn't been released in any official nvme-cli version.

In the timeout case, we can just run "nvme connect-all" now, simplifying the code for the initqueu case, where we apply the previously defined priorities.

@johnmeneghini, this is the part of #7 that got lost when you updated it from to 9865102 and merged it into #6.

If you disagree with this code, please provide a reason.

