### PR TITLE
fix(nvmf): set netroot=nbft

### DIFF
--- a/modules.d/95nvmf/module-setup.sh
+++ b/modules.d/95nvmf/module-setup.sh
@@ -136,6 +136,7 @@ install() {
     inst_multiple ip sed
 
     inst_script "${moddir}/nvmf-autoconnect.sh" /sbin/nvmf-autoconnect.sh
+    inst_script "${moddir}/nbftroot.sh" /sbin/nbftroot
 
     inst_multiple nvme jq
     inst_hook cmdline 92 "$moddir/parse-nvmf-boot-connections.sh"

--- a/modules.d/95nvmf/nbftroot.sh
+++ b/modules.d/95nvmf/nbftroot.sh
@@ -1,0 +1,5 @@
+#! /bin/sh
+# This script is called from /sbin/netroot
+
+/sbin/nvmf-autoconnect.sh online
+exit 0

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -316,9 +316,9 @@ done
 
 if [ -e /tmp/nvmf_needs_network ] || [ -e /tmp/valid_nbft_entry_found ]; then
     echo "rd.neednet=1" > /etc/cmdline.d/nvmf-neednet.conf
+    netroot=nbft
     rm -f /tmp/nvmf_needs_network
 fi
 
-/sbin/initqueue --online --name nvmf-connect-online /sbin/nvmf-autoconnect.sh online
 /sbin/initqueue --settled --onetime --name nvmf-connect-settled /sbin/nvmf-autoconnect.sh settled
 /sbin/initqueue --timeout --onetime --name nvmf-connect-timeout /sbin/nvmf-autoconnect.sh timeout


### PR DESCRIPTION
The logic added in 9b9dd99 ("35network-legacy: only skip waiting for interfaces if netroot is set") will cause all NBFT interfaces to be waited for unless the "netroot" shell variable is set. Avoid this by setting "netroot=nbft": this will cause the boot to proceed even NBFT interfaces are missing, as long as the initrd root file system has been found.

This requires installing a netroot handler /sbin/nbftroot, which will be called by the networking scripts via /sbin/netroot when the interface has been brought up. Create a simple nbftroot script that simply calls nvmf-autoconnect.sh. With this installed, we can skip calling nvmf-autoconnect.sh from the "online" initqueue hook.

Fixes #9, but only for the `network-legacy` networking backend. 

I think that with the network-manager backend, the issue doesn't exist in the first place.
